### PR TITLE
Fixed bug where items added to a cart after an order had been completed, was adding it to the completed order and not a new cart

### DIFF
--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -50,7 +50,7 @@ class Cart(ViewSet):
             HTTP/1.1 204 No Content
         """
         current_user = Customer.objects.get(user=request.auth.user)
-        open_order = Order.objects.get(customer=current_user, payment_type=None)
+        open_order = Order.objects.get(customer=current_user, payment_id=None)
 
         line_item = OrderProduct.objects.filter(product__id=pk, order=open_order)[0]
         line_item.delete()

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -243,7 +243,9 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(
+                    customer=current_user, payment__isnull=True
+                )
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- added a arg for `profile.py`. Before it was only checking if `customer=current_user`. This made it so it automatically adding to a completed order because it wasn't checking for that. I added `payment__isnull=True` to line 247 in `profile.py` view. Now it checks if the order is completed or not and starts a new order if there isn't one open. 

## Requests / Responses

## Testing

Description of how to test code...

Steps to follow.

1. Authenticate the client and get a token
2. Make sure the user has a payment type on file
3. Add a product to the cart by sending a POST request to `http://localhost:8000/profile/cart` (has to be done on Post Man as there is still a frontend bug) with a body of `{"product_id": 119}`
4. Finish the order by hitting `complete order` on Cart page
5. On Post man do a GET request `http://localhost:8000/orders` verify that the order has been completed(payment isn't Null but rather card from the user)
6. Add a product to the cart by sending a POST request to `http://localhost:8000/profile/cart` (has to be done on Post Man as there is still a frontend bug) with a body of `{"product_id": 112}`
7. verify on the `Cart` page that the item has been added to the cart
8. Complete the order on the `Cart` page on frontend
9. one final verification. do a GET request `http://localhost:8000/orders` and verify that each purchase has its own object and that they aren't on one order object. 

## Related Issues

- Fixes #33