### PR TITLE
Jv test - complete order by adding payment type

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -41,8 +41,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()

--- a/tests/order.py
+++ b/tests/order.py
@@ -44,9 +44,9 @@ class OrderTests(APITestCase):
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+        # adding a payment type
         url = "/paymenttypes"
         data = {
-            "id": 4,
             "merchant_name": "American Express",
             "account_number": "111-1111-1111",
             "expiration_date": "2024-12-31",
@@ -107,9 +107,17 @@ class OrderTests(APITestCase):
 
     # TODO: Complete order by adding payment type
     def test_complete_order_by_adding_payment(self):
-        # cart_id = 16
+
+        # Add product to order
+        url = "/cart"
+        data = {"product_id": 1}
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
         # complete an order using cart ID
-        url = "/cart/16/complete"
+        url = "/cart/1/complete"
         data = {"payment_id": self.payment_id}
 
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
@@ -120,6 +128,17 @@ class OrderTests(APITestCase):
         url = "/orders"
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["payment"]["id"], self.payment_id)
+
+        # Check if there is exactly one order
+        self.assertEqual(len(response.data), 1)
+
+        # Get the first (and only) order
+        order = response.data[0]
+
+        # Check if payment information exists
+        self.assertIn("payment", order)
+
+        # Assert that the payment ID matches the expected payment ID
+        self.assertEqual(order["payment"]["id"], self.payment_id)
 
     # TODO: New line item is not added to closed order

--- a/tests/order.py
+++ b/tests/order.py
@@ -42,6 +42,7 @@ class OrderTests(APITestCase):
         }
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
         response = self.client.post(url, data, format="json")
+        self.product = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # adding a payment type
@@ -54,8 +55,8 @@ class OrderTests(APITestCase):
         }
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
         response = self.client.post(url, data, format="json")
-        json_response = json.loads(response.content)
-        self.payment_id = response.data.get("id")  # Store the payment type ID
+        self.payment = json.loads(response.content)
+        # self.payment_id = response.data.get("id")  # Store the payment type ID
 
     def test_add_product_to_order(self):
         """
@@ -110,15 +111,17 @@ class OrderTests(APITestCase):
 
         # Add product to order
         url = "/cart"
-        data = {"product_id": 1}
+        data = {"product_id": self.product["id"]}
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
         response = self.client.post(url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         # complete an order using cart ID
-        url = "/cart/1/complete"
-        data = {"payment_id": self.payment_id}
+        url = f"/cart/{self.payment["id"]}/complete"
+        data = {"payment_id": self.payment["id"]}
+
+
 
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
         response = self.client.put(url, data, format="json")
@@ -139,6 +142,6 @@ class OrderTests(APITestCase):
         self.assertIn("payment", order)
 
         # Assert that the payment ID matches the expected payment ID
-        self.assertEqual(order["payment"]["id"], self.payment_id)
+        self.assertEqual(order["payment"]["id"], self.payment["id"])
 
     # TODO: New line item is not added to closed order


### PR DESCRIPTION
Added a test for completing an order by adding a payment type.

## test_complete_order_by_adding_payment

These are the steps the test goes through

- added a product to the order
- complete an order using cart ID
- Perform GET request to verify the payment type is assigned
- Check if there is exactly one order
- Get the first (and only) order
- Check if payment information exists
- Assert that the payment ID matches the expected payment ID

## Testing

Description of how to test code...

- [ ] Run test suite with `python3 manage.py test tests -v 1` in your api terminal and verify it doesn't fail or throw an error.

## Related Issues

- Test #19 Complete order by adding payment type