### PR TITLE
Jv report/completed orders

### DIFF
--- a/bangazon/templates/index.html
+++ b/bangazon/templates/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{ title }}</title>
+  </head>
+  <body>
+    <h1>{{ heading }}</h1>
+    <p>{{ content }}</p>
+  </body>
+</html>

--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -5,6 +5,7 @@ from rest_framework import routers
 from rest_framework.authtoken.views import obtain_auth_token
 from bangazonapi.models import *
 from bangazonapi.views import *
+from bangazonapi.report_views import paid_orders_report
 
 # pylint: disable=invalid-name
 router = routers.DefaultRouter(trailing_slash=False)
@@ -32,4 +33,5 @@ urlpatterns = [
         Cart.as_view({"put": "complete"}),
         name="cart-complete",
     ),
+    path("reports/orders", paid_orders_report, name="paid_orders_report"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/bangazonapi/report_views/__init__.py
+++ b/bangazonapi/report_views/__init__.py
@@ -1,0 +1,1 @@
+from .orders import paid_orders_report

--- a/bangazonapi/report_views/orders.py
+++ b/bangazonapi/report_views/orders.py
@@ -1,0 +1,27 @@
+# views.py
+
+from django.shortcuts import render
+from bangazonapi.models import Order
+
+
+# def paid_orders_report(request):
+#     # Fetch orders that have been paid for
+#     paid_orders = Order.objects.filter(payment__isnull=False)
+
+#     # Add additional information (customer name, total paid, payment type) to each order
+#     for order in paid_orders:
+#         order.customer_name = order.customer.get_full_name()
+#         order.total_paid = sum(item.product.price for item in order.lineitems.all())
+#         order.payment_type = order.payment.type
+
+#     Pass the paid orders data to the template
+#     return render(request, "paid_orders_report.html", {"paid_orders": paid_orders})
+
+
+def paid_orders_report(request):
+    # Fetch all paid orders
+    paid_orders = Order.objects.filter(payment__isnull=False)
+
+    context = {"paid_orders": paid_orders}
+
+    return render(request, "paid_orders_report.html", context)

--- a/bangazonapi/report_views/orders.py
+++ b/bangazonapi/report_views/orders.py
@@ -18,10 +18,30 @@ from bangazonapi.models import Order
 #     return render(request, "paid_orders_report.html", {"paid_orders": paid_orders})
 
 
+# def paid_orders_report(request):
+#     # Fetch all paid orders
+#     paid_orders = Order.objects.filter(payment__isnull=False)
+
+#     context = {"paid_orders": paid_orders}
+
+#     return render(request, "paid_orders_report.html", context)
+
+
 def paid_orders_report(request):
-    # Fetch all paid orders
     paid_orders = Order.objects.filter(payment__isnull=False)
 
-    context = {"paid_orders": paid_orders}
+    orders_with_info = []
 
-    return render(request, "paid_orders_report.html", context)
+    for order in paid_orders:
+        total_price = sum(item.product.price for item in order.lineitems.all())
+
+        order_info = {
+            "id": order.id,
+            "customer_name": order.customer.user.first_name,
+            "total_price": total_price,
+            "payment_type": order.payment.merchant_name,
+        }
+
+        orders_with_info.append(order_info)
+
+    return render(request, "paid_orders_report.html", {"paid_orders": orders_with_info})

--- a/bangazonapi/templates/paid_orders_report.html
+++ b/bangazonapi/templates/paid_orders_report.html
@@ -1,0 +1,33 @@
+<!-- paid_orders_report.html -->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Paid Orders Report</title>
+</head>
+<body>
+    <h1>Paid Orders Report</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>Order ID</th>
+                <th>Customer Name</th>
+                <th>Total Paid</th>
+                <th>Payment Type</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for order in paid_orders %}
+                <tr>
+                    <td>{{ order.id }}</td>
+                    <td>{{ order.customer.user.first_name }}</td>
+                    <td>{{ order.lineitems.product.price }}</td>
+                    <td>{{ order.payment.merchant_name }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/bangazonapi/templates/paid_orders_report.html
+++ b/bangazonapi/templates/paid_orders_report.html
@@ -2,32 +2,32 @@
 
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Paid Orders Report</title>
-</head>
-<body>
+  </head>
+  <body>
     <h1>Paid Orders Report</h1>
     <table>
-        <thead>
-            <tr>
-                <th>Order ID</th>
-                <th>Customer Name</th>
-                <th>Total Paid</th>
-                <th>Payment Type</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for order in paid_orders %}
-                <tr>
-                    <td>{{ order.id }}</td>
-                    <td>{{ order.customer.user.first_name }}</td>
-                    <td>{{ order.lineitems.product.price }}</td>
-                    <td>{{ order.payment.merchant_name }}</td>
-                </tr>
-            {% endfor %}
-        </tbody>
+      <thead>
+        <tr>
+          <th>Order ID</th>
+          <th>Customer Name</th>
+          <th>Total Paid</th>
+          <th>Payment Type</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for order in paid_orders %}
+        <tr>
+          <td>{{ order.id }}</td>
+          <td>{{ order.customer_name }}</td>
+          <td>{{ order.total_price}}</td>
+          <td>{{ order.payment_type}}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
     </table>
-</body>
+  </body>
 </html>

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -153,17 +153,3 @@ class Orders(ViewSet):
         json_orders = OrderSerializer(orders, many=True, context={"request": request})
 
         return Response(json_orders.data)
-
-
-def paid_orders_report(request):
-    # Fetch orders that have been paid for
-    paid_orders = Order.objects.filter(payment__isnull=False)
-
-    # Add additional information (customer name, total paid, payment type) to each order
-    for order in paid_orders:
-        order.customer_name = order.customer.get_full_name()
-        order.total_paid = sum(item.product.price for item in order.lineitems.all())
-        order.payment_type = order.payment.type
-
-    # Pass the paid orders data to the template
-    return render(request, "paid_orders_report.html", {"paid_orders": paid_orders})

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -2,6 +2,7 @@
 
 import datetime
 from django.http import HttpResponseServerError
+from django.shortcuts import render
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
@@ -152,3 +153,17 @@ class Orders(ViewSet):
         json_orders = OrderSerializer(orders, many=True, context={"request": request})
 
         return Response(json_orders.data)
+
+
+def paid_orders_report(request):
+    # Fetch orders that have been paid for
+    paid_orders = Order.objects.filter(payment__isnull=False)
+
+    # Add additional information (customer name, total paid, payment type) to each order
+    for order in paid_orders:
+        order.customer_name = order.customer.get_full_name()
+        order.total_paid = sum(item.product.price for item in order.lineitems.all())
+        order.payment_type = order.payment.type
+
+    # Pass the paid orders data to the template
+    return render(request, "paid_orders_report.html", {"paid_orders": paid_orders})

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -41,8 +41,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()

--- a/bangazonapi/views/report.py
+++ b/bangazonapi/views/report.py
@@ -1,0 +1,4 @@
+from .order import Orders
+
+
+paid_orders_report()

--- a/bangazonapi/views/report.py
+++ b/bangazonapi/views/report.py
@@ -1,4 +1,0 @@
-from .order import Orders
-
-
-paid_orders_report()

--- a/tests/order.py
+++ b/tests/order.py
@@ -44,9 +44,9 @@ class OrderTests(APITestCase):
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+        # adding a payment type
         url = "/paymenttypes"
         data = {
-            "id": 4,
             "merchant_name": "American Express",
             "account_number": "111-1111-1111",
             "expiration_date": "2024-12-31",
@@ -107,9 +107,17 @@ class OrderTests(APITestCase):
 
     # TODO: Complete order by adding payment type
     def test_complete_order_by_adding_payment(self):
-        # cart_id = 16
+
+        # Add product to order
+        url = "/cart"
+        data = {"product_id": 1}
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
         # complete an order using cart ID
-        url = "/cart/16/complete"
+        url = "/cart/1/complete"
         data = {"payment_id": self.payment_id}
 
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
@@ -120,6 +128,17 @@ class OrderTests(APITestCase):
         url = "/orders"
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["payment"]["id"], self.payment_id)
+
+        # Check if there is exactly one order
+        self.assertEqual(len(response.data), 1)
+
+        # Get the first (and only) order
+        order = response.data[0]
+
+        # Check if payment information exists
+        self.assertIn("payment", order)
+
+        # Assert that the payment ID matches the expected payment ID
+        self.assertEqual(order["payment"]["id"], self.payment_id)
 
     # TODO: New line item is not added to closed order


### PR DESCRIPTION
So Jordan started writing a report to find all the paid orders and get their total. He ran so far

## Changes

report_views/orders.py
templates/paid_orders_report.html
views/order.py

## Requests / Responses

if you go to http://localhost:8000/reports/orders?status=complete, while your debugger is running in your api, then you will see a list of paid orders with their order id, customer name, total paid, and the payment type. 

Description of how to test code...

- [ ] Run debugger in api
- [ ] go to your browser
- [ ] put `http://localhost:8000/reports/orders?status=complete` in the url bar
- [ ] check to see if the Paid Orders Report shows and it has all the right info


report ticket #10