### PR TITLE
added unpaid orders report

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -5,7 +5,7 @@ from rest_framework import routers
 from rest_framework.authtoken.views import obtain_auth_token
 from bangazonapi.models import *
 from bangazonapi.views import *
-from bangazonapi.report_views import paid_orders_report
+from bangazonapi.report_views import paid_orders_report, unpaid_orders_report
 
 # pylint: disable=invalid-name
 router = routers.DefaultRouter(trailing_slash=False)
@@ -35,5 +35,8 @@ urlpatterns = [
         Cart.as_view({"put": "complete"}),
         name="cart-complete",
     ),
-    path("reports/orders", paid_orders_report, name="paid_orders_report"),
+    path("reports/complete_orders", paid_orders_report, name="paid_orders_report"),
+    path(
+        "reports/incomplete_orders", unpaid_orders_report, name="unpaid_orders_report"
+    ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/bangazonapi/report_views/__init__.py
+++ b/bangazonapi/report_views/__init__.py
@@ -1,1 +1,2 @@
 from .orders import paid_orders_report
+from .orders import unpaid_orders_report

--- a/bangazonapi/report_views/orders.py
+++ b/bangazonapi/report_views/orders.py
@@ -1,35 +1,11 @@
 # views.py
 
 from django.shortcuts import render
-from bangazonapi.models import Order, OrderProduct
-
-
-# def paid_orders_report(request):
-#     # Fetch orders that have been paid for
-#     paid_orders = Order.objects.filter(payment__isnull=False)
-
-#     # Add additional information (customer name, total paid, payment type) to each order
-#     for order in paid_orders:
-#         order.customer_name = order.customer.get_full_name()
-#         order.total_paid = sum(item.product.price for item in order.lineitems.all())
-#         order.payment_type = order.payment.type
-
-#     Pass the paid orders data to the template
-#     return render(request, "paid_orders_report.html", {"paid_orders": paid_orders})
-
-
-# def paid_orders_report(request):
-#     # Fetch all paid orders
-#     paid_orders = Order.objects.filter(payment__isnull=False)
-
-#     context = {"paid_orders": paid_orders}
-
-#     return render(request, "paid_orders_report.html", context)
+from bangazonapi.models import Order
 
 
 def paid_orders_report(request):
     paid_orders = Order.objects.filter(payment__isnull=False)
-    # line_item = OrderProduct.objects.get()
 
     orders_with_info = []
 
@@ -46,3 +22,24 @@ def paid_orders_report(request):
         orders_with_info.append(order_info)
 
     return render(request, "paid_orders_report.html", {"paid_orders": orders_with_info})
+
+
+def unpaid_orders_report(request):
+    unpaid_orders = Order.objects.filter(payment__isnull=True)
+
+    orders_without_payment = []
+
+    for order in unpaid_orders:
+        total_price = sum(item.product.price for item in order.lineitems.all())
+
+        order_info = {
+            "id": order.id,
+            "customer_name": order.customer.user.first_name,
+            "total_price": total_price,
+        }
+
+        orders_without_payment.append(order_info)
+
+    return render(
+        request, "unpaid_orders_report.html", {"unpaid_orders": orders_without_payment}
+    )

--- a/bangazonapi/templates/unpaid_orders_report.html
+++ b/bangazonapi/templates/unpaid_orders_report.html
@@ -1,0 +1,31 @@
+<!-- unpaid_orders_report.html -->
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Unpaid Orders Report</title>
+  </head>
+  <body>
+    <h1>Unpaid Orders Report</h1>
+    <table>
+      <thead>
+        <tr>
+          <th>Order Id</th>
+          <th>Customer Name</th>
+          <th>Order Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for order in unpaid_orders %}
+        <tr>
+          <td>{{order.id}}</td>
+          <td>{{order.customer_name}}</td>
+          <td>{{order.total_price}}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
Added the ability to get a report to see all unpaid orders

## Changes

- added bangazonapi/templates/unpaid_orders_report.html
- updated bangazonapi/report_views/orders.py
- updated bangazonapi/report_views/__init__.py
- updated bangazon/urls.py


Description of how to test code...

- [ ] Run api debugger
- [ ] Open browser and navigate to http://localhost:8000/reports/incomplete_orders
- [ ] Make sure it shows incompleted orders


Also updated bangazon/urls.py so that the paid orders report url path shows "complete_orders" and not just "orders"

